### PR TITLE
Correcting match thread post title

### DIFF
--- a/mls_reddit_bot/postbody.py
+++ b/mls_reddit_bot/postbody.py
@@ -6,7 +6,7 @@ import pytz
 import datetime
 
 def get_submission_title(event):
-    return f'Match Thread: {event.away_team_fullname} @ {event.home_team_fullname}'
+    return f'Match Thread: {event.home_team_fullname} vs. {event.away_team_fullname}'
 
 def _get_bot_footer():
     tz = pytz.timezone('US/Central')


### PR DESCRIPTION
In soccer, the home team is listed first.  While `Away @ Home` is standard for other sports in the US, Canada, and Japan, even in those countries, soccer follows the international standard of `Home vs. Away`.

[Explanation](https://www.sportsbookadvisor.com/2024/01/02/home-vs-away-or-away-vs-home-how-to-tell-which-team-is-the-home-team/#:~:text=Part%20of%20the%20confusion%20as%20to%20which%20team,and%20Japan%2C%20the%20home%20team%20is%20listed%20second.)

Sources: [ESPN](https://www.espn.com/soccer/match/_/gameId/692896), [MLS](https://www.mlssoccer.com/schedule/scores#competition=mls-regular-season&club=all&date=2024-06-28), [Fox Sports](https://www.foxsports.com/soccer/mls-seattle-sounders-fc-vs-chicago-fire-jun-29-2024-game-boxscore-133280), [Apple TV](https://tv.apple.com/us/sporting-event/seattle-sounders-fc-vs-chicago-fire-fc/umc.cse.6is9s7yhlh1zhjy2fwjass87l?ctx_brand=tvs.sbd.7000)